### PR TITLE
Make configuration safe across multi threaded environments

### DIFF
--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json_pure', '~> 1.5')
   s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('request_store', '~> 1.0')
 
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('mocha')

--- a/lib/chargebee.rb
+++ b/lib/chargebee.rb
@@ -1,3 +1,5 @@
+require 'request_store'
+
 require File.dirname(__FILE__) + '/chargebee/environment'
 require File.dirname(__FILE__) + '/chargebee/rest'
 require File.dirname(__FILE__) + '/chargebee/util'
@@ -34,16 +36,15 @@ module ChargeBee
 
   VERSION = '2.0.2'
 
-  @@default_env = nil
   @@verify_ca_certs = true
   @@ca_cert_path = File.join(File.dirname(__FILE__), '/ssl/ca-certs.crt')
 
   def self.configure(options)
-    @@default_env = Environment.new(options)
+    RequestStore.store[:chargebee_default_env] = Environment.new(options)
   end
 
   def self.default_env
-    @@default_env
+    RequestStore.store[:chargebee_default_env]
   end
 
   def self.verify_ca_certs=(verify)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,13 @@ require 'json'
 
 RSpec.configure do |config|
   config.mock_with :mocha
+
+  config.before(:each) do
+    ChargeBee.configure(
+      :api_key => "dummy_api_key",
+      :site => "dummy_site"
+    )
+  end
 end
 
 def mock_response(body, code=200)
@@ -18,7 +25,3 @@ def mock_response(body, code=200)
   m
 end
 
-ChargeBee.configure(
-  :api_key => "dummy_api_key", 
-  :site => "dummy_site"
-)


### PR DESCRIPTION
Currently, the configuration is being stored as a class level variable.
That renders the gem thread unsafe. This might be OK if you're using it from rails
on a simple setup with single threaded requests, But if you're running multi-threaded
rack servers like Puma or Thin, or even a background job processor like Sidekiq, you might
run into trouble.

This change consists into storing the configuration on `Thread.current` instead of a class variable.
The choice for the `request_store` gem makes sense since it provides a rack middleware to clear
`Current.thread` after each request.

I understand that this might be an issue since some people are probably configuring the gem on a initializer instead of doing it at a request level. But if you have more than one ChargeBee site (as I imagine most people will) and you call `ChargeBee.configure` on each request, this change will not affect you at all.