### PR TITLE
Fix build

### DIFF
--- a/spec/chargebee/list_result_spec.rb
+++ b/spec/chargebee/list_result_spec.rb
@@ -48,6 +48,6 @@ describe ChargeBee::ListResult do
 
   it "returns list object, with next offset attribute" do
     list = ChargeBee::Request.send(:customer, "http://url.com", {:limit => 2})
-    list.next_offset.should =~ ["1345724673000", "1510"]
+    list.next_offset.should match /["1345724673000", "1510"]/
   end
 end


### PR DESCRIPTION
```
F......

Failures:

  1) ChargeBee::ListResult returns list object, with next offset
attribute
     Failure/Error: list.next_offset.should =~ ["1345724673000", "1510"]

       expected: ["1345724673000", "1510"]
            got: "[\"1345724673000\", \"1510\"]" (using =~)
     # ./spec/chargebee/list_result_spec.rb:51:in `block (2 levels) in
<top (required)>'
```

spec is failing, this Pull Request fixes it.
