### PR TITLE
only rescue RestClient exceptions

### DIFF
--- a/lib/chargebee/rest.rb
+++ b/lib/chargebee/rest.rb
@@ -49,7 +49,7 @@ module ChargeBee
         else
             raise IOError.new("IO Exception when trying to connect to chargebee with url #{opts[:url]} . Reason #{e}",e)
         end
-      rescue Exception => e
+      rescue RestClient::Exception => e
             raise IOError.new("IO Exception when trying to connect to chargebee with url #{opts[:url]} . Reason #{e}",e)        
       end
       rbody = response.body


### PR DESCRIPTION
Currently all errors coming from the depths of rest-client are rescued and translated to `IOError`. I suggest to change it:

1. It's a bad practice to rescue `Exception`. If you want to rescue all exceptions, rescue `StandardError`. [Here's why.](https://robots.thoughtbot.com/rescue-standarderror-not-exception)
2. As in the scenario described in #15, an error may occasionally happen somewhere deep in rest-client, that has nothing to do with network communication, but results solely from gems incompatibility or other client-side software misfortune. It is really misleading to mask such errors as `IOError`.

I believe the right thing to do is to only handle exceptions raised by rest-client (which fortunately have a common ancestor `RestClient::Exception`). rest-client already does an awesome job handling various exceptions from the layers below and translating them to instances of it's own exception types, so you can be assured that exceptions of other types aren't "mere IO errors" and signal deeper problems.