### PR TITLE
Fix errors initializer argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+Gemfile.lock
 
 #chargebee ignores
 snippets.rb

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/tmp
 test/version_tmp
 tmp
 Gemfile.lock
+.rspec
 
 #chargebee ignores
 snippets.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/chargebee/errors.rb
+++ b/lib/chargebee/errors.rb
@@ -3,9 +3,9 @@ module ChargeBee
   class Error < StandardError
     attr_reader :original_error
 
-    def initialize(message=nil,original_error = nil)
-        super message
-        @original_error = original_error
+    def initialize(message = nil, original_error = {})
+      super message
+      @original_error = original_error
     end
   end
 
@@ -16,8 +16,8 @@ module ChargeBee
     attr_reader  :http_status_code, :type, :api_error_code, :param, :json_obj,
                  #Deprecated attributes
                  :http_code, :http_body, :error_code
-    
-    def initialize(http_code=nil, json_obj = nil)
+
+    def initialize(http_code = nil, json_obj = {})
       super json_obj[:message]
       @json_obj = json_obj
       @http_status_code = http_code
@@ -30,7 +30,7 @@ module ChargeBee
       @http_code = http_code
       @http_body = json_obj.to_s
     end
-    
+
   end
 
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'ChargeBee::InvalidRequestError' do
+
   let(:invalid_request_json) do
     {
         message:  'id: The value chargebee_account is already present.',
@@ -14,10 +15,14 @@ describe 'ChargeBee::InvalidRequestError' do
     }
   end
 
-  it "provide message from error api response" do
+  it 'provide message from error api response' do
     error = ChargeBee::InvalidRequestError.new(400, invalid_request_json)
     error.message.should eq 'id: The value chargebee_account is already present.'
   end
 
-end
+  it 'allows empty arguments' do
+    error = ChargeBee::InvalidRequestError.new
+    error.message.should eq 'ChargeBee::InvalidRequestError'
+  end
 
+end


### PR DESCRIPTION
This fix allows `Error` to be initialized with empty arguments without blowing up.

The spec is still broken, please consider merging this [PR](https://github.com/chargebee/chargebee-ruby/pull/11) as well.