### PR TITLE
rest-client version check modified to support >=1.4.

### DIFF
--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.rdoc LICENSE]
 
   s.add_dependency('json_pure', '~> 1.5')
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '>= 1.4')
 
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('mocha')

--- a/spec/chargebee/list_result_spec.rb
+++ b/spec/chargebee/list_result_spec.rb
@@ -48,6 +48,6 @@ describe ChargeBee::ListResult do
 
   it "returns list object, with next offset attribute" do
     list = ChargeBee::Request.send(:customer, "http://url.com", {:limit => 2})
-    list.next_offset.should =~ ["1345724673000", "1510"]
+    list.next_offset.should =~ /["1345724673000", "1510"]/
   end
 end


### PR DESCRIPTION
rest-client version 1.4 is very old and lots of other gems had moved to > 2.0. 

Having minor version check ~>1.4 is a blocker in using many other gems. There is no major deprecation in the rest-client api as such compared to > 1.4 versions to 2.* versions. Its mostly additions on 'Exceptions' module. 

Tested the specs after modifying it to >=1.4 All specs passed.
Also refering issue: https://github.com/chargebee/chargebee-ruby/issues/19