### PR TITLE
Fix implementation of method_missing

### DIFF
--- a/lib/chargebee/models/model.rb
+++ b/lib/chargebee/models/model.rb
@@ -46,8 +46,8 @@ module ChargeBee
       elsif(m[0,3] == "cf_") # All the custom fields start with prefix cf_. 
           return nil
       end
-      puts "There's no method called #{m} #{args} here -- please try again."
-      puts @values
+      
+      super
     end
     
     def self.uri_path(*paths) 


### PR DESCRIPTION
This removes a puts warning for method_missing, and replaces it with a super call. This is how method_missing is normally implemented in Ruby.