### PR TITLE
switch to multi_json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in crypto_exchanges.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    chargebee (2.5.4)
+      multi_json (~> 1.0)
+      rest-client (>= 1.8, < 3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json_pure (2.1.0)
+    metaclass (0.0.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mocha (1.5.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.13.1)
+    netrc (0.11.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  chargebee!
+  json_pure (~> 2.1)
+  mocha
+  rspec (~> 3.0.0)
+
+BUNDLED WITH
+   1.16.1

--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -20,11 +20,12 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.rdoc LICENSE]
 
-  s.add_dependency('json_pure', '~> 2.1')
+  s.add_dependency 'multi_json', '~> 1.0'
   s.add_dependency('rest-client', '>= 1.8', '< 3.0')
 
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('mocha')
+  s.add_development_dependency('json_pure', '~> 2.1')
 
   # = MANIFEST =
   s.files = %w[

--- a/lib/chargebee.rb
+++ b/lib/chargebee.rb
@@ -22,6 +22,7 @@ require File.dirname(__FILE__) + '/chargebee/models/subscription_estimate'
 require File.dirname(__FILE__) + '/chargebee/models/invoice_estimate'
 require File.dirname(__FILE__) + '/chargebee/models/credit_note_estimate'
 require File.dirname(__FILE__) + '/chargebee/models/hosted_page'
+require 'multi_json'
 require File.dirname(__FILE__) + '/chargebee/models/event'
 require File.dirname(__FILE__) + '/chargebee/models/plan'
 require File.dirname(__FILE__) + '/chargebee/models/addon'
@@ -80,4 +81,3 @@ module ChargeBee
   end
 
 end
-

--- a/lib/chargebee/list_result.rb
+++ b/lib/chargebee/list_result.rb
@@ -1,28 +1,28 @@
 require 'forwardable'
 
 module ChargeBee
-  class ListResult 
+  class ListResult
     extend Forwardable
     include Enumerable
-    
+
     def_delegator :@list, :each, :each
     def_delegator :@list, :length, :length
-    
+
     attr_reader :next_offset
 
     def initialize(response, next_offset=nil)
       @response = response
       @list = Array.new
-      @next_offset = JSON.parse(next_offset).to_s if next_offset
+      @next_offset = next_offset
       initItems()
     end
-    
+
     private
     def initItems()
       @response.each do |item|
         @list.push(Result.new(item))
       end
     end
-  
+
   end
 end

--- a/lib/chargebee/models/event.rb
+++ b/lib/chargebee/models/event.rb
@@ -5,42 +5,42 @@ module ChargeBee
       attr_accessor :id, :webhook_status
     end
 
-  attr_accessor :id, :occurred_at, :source, :user, :webhook_status, :webhook_failure_reason, :webhooks,
-  :event_type, :api_version
+    attr_accessor :id, :occurred_at, :source, :user, :webhook_status, :webhook_failure_reason, :webhooks,
+      :event_type, :api_version
 
-  class Content < Result
-  end
-
-  def content
-    Content.new(@values[:content])
-  end
-
-  def self.deserialize(json)
-    begin
-      webhook_data = JSON.parse(json)
-    rescue JSON::ParserError => e
-      raise Error.new("Invalid webhook object to deserialize. #{e}",e)
+    class Content < Result
     end
 
-    api_version = webhook_data["api_version"]
-    if api_version != nil && api_version.casecmp(Environment::API_VERSION) != 0
-       raise Error.new("API version [#{api_version.upcase}] in response does not match with client library API version [#{Environment::API_VERSION.upcase}]")
+    def content
+      Content.new(@values[:content])
     end
 
-    webhook_data = Util.symbolize_keys(webhook_data)
-    Event.construct(webhook_data)
-  end
+    def self.deserialize(json)
+      begin
+        webhook_data = MultiJson.load(json)
+      rescue MultiJson::ParseError => e
+        raise Error.new("Invalid webhook object to deserialize. #{e}",e)
+      end
 
-  # OPERATIONS
-  #-----------
+      api_version = webhook_data["api_version"]
+      if api_version != nil && api_version.casecmp(Environment::API_VERSION) != 0
+        raise Error.new("API version [#{api_version.upcase}] in response does not match with client library API version [#{Environment::API_VERSION.upcase}]")
+      end
 
-  def self.list(params={}, env=nil, headers={})
-    Request.send_list_request('get', uri_path("events"), params, env, headers)
-  end
+      webhook_data = Util.symbolize_keys(webhook_data)
+      Event.construct(webhook_data)
+    end
 
-  def self.retrieve(id, env=nil, headers={})
-    Request.send('get', uri_path("events",id.to_s), {}, env, headers)
-  end
+    # OPERATIONS
+    #-----------
+
+    def self.list(params={}, env=nil, headers={})
+      Request.send_list_request('get', uri_path("events"), params, env, headers)
+    end
+
+    def self.retrieve(id, env=nil, headers={})
+      Request.send('get', uri_path("events",id.to_s), {}, env, headers)
+    end
 
   end # ~Event
 end # ~ChargeBee

--- a/lib/chargebee/models/export.rb
+++ b/lib/chargebee/models/export.rb
@@ -5,47 +5,47 @@ module ChargeBee
       attr_accessor :download_url, :valid_till
     end
 
-  attr_accessor :operation_type, :mime_type, :status, :created_at, :id, :download
-def wait_for_export_completion(env = nil, headers={})
-  env = env || ChargeBee.default_env
-  sleeptime = env.export_sleeptime
+    attr_accessor :operation_type, :mime_type, :status, :created_at, :id, :download
+    def wait_for_export_completion(env = nil, headers={})
+      env = env || ChargeBee.default_env
+      sleeptime = env.export_sleeptime
 
-  export_final = (1..50).inject(self) do |export|
-    break export if export.status != "in_process"
-    sleep(sleeptime)
-    self.class.retrieve(self.id, env, headers).export
-  end
+      export_final = (1..50).inject(self) do |export|
+        break export if export.status != "in_process"
+        sleep(sleeptime)
+        self.class.retrieve(self.id, env, headers).export
+      end
 
-  # sync last fetched one with the current instance
-  new_values = export_final.instance_variable_get("@values")
-  self.instance_variable_set("@values", new_values)
-  self.load(new_values)
+      # sync last fetched one with the current instance
+      new_values = export_final.instance_variable_get("@values")
+      self.instance_variable_set("@values", new_values)
+      self.load(new_values)
 
-  case export_final.status
-  when "in_process"
-    raise Error.new('Export is taking too long')
-  when "failed"
-    json_obj = Util.symbolize_keys(JSON.parse(self.error_json))
-    raise OperationFailedError.new(json_obj[:http_code], json_obj)
-  when "not_enabled", "_unknown"
-    raise Error.new("Export status is in wrong state #{self.status}")
-  end
-end
+      case export_final.status
+      when "in_process"
+        raise Error.new('Export is taking too long')
+      when "failed"
+        json_obj = Util.symbolize_keys(MultiJson.load(self.error_json))
+        raise OperationFailedError.new(json_obj[:http_code], json_obj)
+      when "not_enabled", "_unknown"
+        raise Error.new("Export status is in wrong state #{self.status}")
+      end
+    end
 
-  # OPERATIONS
-  #-----------
+    # OPERATIONS
+    #-----------
 
-  def self.retrieve(id, env=nil, headers={})
-    Request.send('get', uri_path("exports",id.to_s), {}, env, headers)
-  end
+    def self.retrieve(id, env=nil, headers={})
+      Request.send('get', uri_path("exports",id.to_s), {}, env, headers)
+    end
 
-  def self.revenue_recognition(params, env=nil, headers={})
-    Request.send('post', uri_path("exports","revenue_recognition"), params, env, headers)
-  end
+    def self.revenue_recognition(params, env=nil, headers={})
+      Request.send('post', uri_path("exports","revenue_recognition"), params, env, headers)
+    end
 
-  def self.deferred_revenue(params, env=nil, headers={})
-    Request.send('post', uri_path("exports","deferred_revenue"), params, env, headers)
-  end
+    def self.deferred_revenue(params, env=nil, headers={})
+      Request.send('post', uri_path("exports","deferred_revenue"), params, env, headers)
+    end
 
   end # ~Export
 end # ~ChargeBee

--- a/lib/chargebee/models/model.rb
+++ b/lib/chargebee/models/model.rb
@@ -2,21 +2,21 @@ require 'uri'
 
 module ChargeBee
   class Model
-    
+
     def initialize(values, sub_types={}, dependant_types={})
       @values = values
       @sub_types = sub_types
       @dependant_types = dependant_types
     end
-    
-    def to_s(*args) 
-      JSON.pretty_generate(@values) 
+
+    def to_s(*args)
+      MultiJson.dump(@values, :pretty => true)
     end
-    
+
     def inspect()
-      "#<#{self.class}:0x#{self.object_id.to_s(16)} > JSON: " + JSON.pretty_generate(@values)
+      "#<#{self.class}:0x#{self.object_id.to_s(16)} > JSON: " + MultiJson.dump(@values, :pretty => true)
     end
-    
+
     def load(values)
       instance_eval do
         values.each do |k, v|
@@ -39,28 +39,28 @@ module ChargeBee
         end
       end
     end
-      
+
     def method_missing(m, *args, &block)
       if(@values.has_key?(m))
-          return @values[m]
-      elsif(m[0,3] == "cf_") # All the custom fields start with prefix cf_. 
-          return nil
+        return @values[m]
+      elsif(m[0,3] == "cf_") # All the custom fields start with prefix cf_.
+        return nil
       end
       puts "There's no method called #{m} #{args} here -- please try again."
       puts @values
     end
-    
-    def self.uri_path(*paths) 
+
+    def self.uri_path(*paths)
       url = ""
       for path in paths
-          if(path.nil? || path.strip.length < 1) 
-             raise "Id is empty or nil" 
-          end
-          url = "#{url}/#{URI.encode(path.strip)}"
+        if(path.nil? || path.strip.length < 1)
+          raise "Id is empty or nil"
+        end
+        url = "#{url}/#{URI.encode(path.strip)}"
       end
       return url
     end
-    
+
     def self.construct(values, sub_types = {}, dependant_types = {})
       if(values != nil)
         obj = self.new(values, sub_types, dependant_types)
@@ -68,7 +68,7 @@ module ChargeBee
         obj
       end
     end
-    
+
     def init_dependant(obj, type, sub_types = {})
       instance_eval do
         if(obj[type] != nil)
@@ -82,7 +82,7 @@ module ChargeBee
         end
       end
     end
-    
+
     def init_dependant_list(obj, type, sub_types = {})
       instance_eval do
         if(obj[type] != nil)
@@ -96,6 +96,6 @@ module ChargeBee
         end
       end
     end
-    
+
   end
 end

--- a/lib/chargebee/models/time_machine.rb
+++ b/lib/chargebee/models/time_machine.rb
@@ -1,47 +1,47 @@
 module ChargeBee
   class TimeMachine < Model
 
-  attr_accessor :name, :time_travel_status, :genesis_time, :destination_time, :failure_code, :failure_reason,
-  :error_json
-  def wait_for_time_travel_completion(env = nil)
-    env = env || ChargeBee.default_env
-    sleeptime = env.time_machine_sleeptime
+    attr_accessor :name, :time_travel_status, :genesis_time, :destination_time, :failure_code, :failure_reason,
+      :error_json
+    def wait_for_time_travel_completion(env = nil)
+      env = env || ChargeBee.default_env
+      sleeptime = env.time_machine_sleeptime
 
-    tm = (1..30).inject(self) do |time_machine|
-      break time_machine if time_machine.time_travel_status != "in_progress"
-      sleep(sleeptime)
-      self.class.retrieve(self.name, env).time_machine
+      tm = (1..30).inject(self) do |time_machine|
+        break time_machine if time_machine.time_travel_status != "in_progress"
+        sleep(sleeptime)
+        self.class.retrieve(self.name, env).time_machine
+      end
+
+      # sync last fetched one with the current instance
+      new_values = tm.instance_variable_get("@values")
+      self.instance_variable_set("@values", new_values)
+      self.load(new_values)
+
+      case tm.time_travel_status
+      when "in_progress"
+        raise Error.new('The time travel is taking too much time')
+      when "failed"
+        json_obj = Util.symbolize_keys(MultiJson.load(self.error_json))
+        raise OperationFailedError.new(json_obj[:http_code], json_obj)
+      when "not_enabled", "_unknown"
+        raise Error.new("Time travel status is in wrong state #{self.time_travel_status}")
+      end
+    end
+    # OPERATIONS
+    #-----------
+
+    def self.retrieve(id, env=nil, headers={})
+      Request.send('get', uri_path("time_machines",id.to_s), {}, env, headers)
     end
 
-    # sync last fetched one with the current instance
-    new_values = tm.instance_variable_get("@values")
-    self.instance_variable_set("@values", new_values)
-    self.load(new_values)
-
-    case tm.time_travel_status
-    when "in_progress"
-      raise Error.new('The time travel is taking too much time')
-    when "failed"
-      json_obj = Util.symbolize_keys(JSON.parse(self.error_json))
-      raise OperationFailedError.new(json_obj[:http_code], json_obj)
-    when "not_enabled", "_unknown"
-      raise Error.new("Time travel status is in wrong state #{self.time_travel_status}")
+    def self.start_afresh(id, params={}, env=nil, headers={})
+      Request.send('post', uri_path("time_machines",id.to_s,"start_afresh"), params, env, headers)
     end
-  end
-  # OPERATIONS
-  #-----------
 
-  def self.retrieve(id, env=nil, headers={})
-    Request.send('get', uri_path("time_machines",id.to_s), {}, env, headers)
-  end
-
-  def self.start_afresh(id, params={}, env=nil, headers={})
-    Request.send('post', uri_path("time_machines",id.to_s,"start_afresh"), params, env, headers)
-  end
-
-  def self.travel_forward(id, params={}, env=nil, headers={})
-    Request.send('post', uri_path("time_machines",id.to_s,"travel_forward"), params, env, headers)
-  end
+    def self.travel_forward(id, params={}, env=nil, headers={})
+      Request.send('post', uri_path("time_machines",id.to_s,"travel_forward"), params, env, headers)
+    end
 
   end # ~TimeMachine
 end # ~ChargeBee

--- a/lib/chargebee/request.rb
+++ b/lib/chargebee/request.rb
@@ -1,5 +1,5 @@
 module ChargeBee
-  class Request    
+  class Request
 
     def self.send_list_request(method, url, params={}, env=nil, headers={})
       serialized = {}
@@ -8,8 +8,8 @@ module ChargeBee
           v = v.to_json
         end
         serialized["#{k}"] = v
-      end 
-      self.send(method, url, serialized, env, headers) 
+      end
+      self.send(method, url, serialized, env, headers)
     end
 
     def self.send(method, url, params={}, env=nil, headers={})
@@ -17,11 +17,11 @@ module ChargeBee
       ser_params = Util.serialize(params)
       resp = Rest.request(method, url, env, ser_params||={}, headers)
       if resp.has_key?(:list)
-        ListResult.new(resp[:list], resp[:next_offset]) 
-      else 
+        ListResult.new(resp[:list], resp[:next_offset])
+      else
         Result.new(resp)
       end
     end
-      
+
   end
 end

--- a/lib/chargebee/result.rb
+++ b/lib/chargebee/result.rb
@@ -4,193 +4,193 @@ module ChargeBee
     def initialize(response)
       @response = response
     end
-    
-    def subscription() 
-        subscription = get(:subscription, Subscription,
-        {:addons => Subscription::Addon, :coupons => Subscription::Coupon, :shipping_address => Subscription::ShippingAddress, :referral_info => Subscription::ReferralInfo});
-        return subscription;
+
+    def subscription()
+      subscription = get(:subscription, Subscription,
+                         {:addons => Subscription::Addon, :coupons => Subscription::Coupon, :shipping_address => Subscription::ShippingAddress, :referral_info => Subscription::ReferralInfo});
+      return subscription;
     end
 
-    def customer() 
-        customer = get(:customer, Customer,
-        {:billing_address => Customer::BillingAddress, :referral_urls => Customer::ReferralUrl, :contacts => Customer::Contact, :payment_method => Customer::PaymentMethod, :balances => Customer::Balance});
-        return customer;
+    def customer()
+      customer = get(:customer, Customer,
+                     {:billing_address => Customer::BillingAddress, :referral_urls => Customer::ReferralUrl, :contacts => Customer::Contact, :payment_method => Customer::PaymentMethod, :balances => Customer::Balance});
+      return customer;
     end
 
-    def contact() 
-        contact = get(:contact, Contact);
-        return contact;
+    def contact()
+      contact = get(:contact, Contact);
+      return contact;
     end
 
-    def payment_source() 
-        payment_source = get(:payment_source, PaymentSource,
-        {:card => PaymentSource::Card, :bank_account => PaymentSource::BankAccount, :amazon_payment => PaymentSource::AmazonPayment, :paypal => PaymentSource::Paypal});
-        return payment_source;
+    def payment_source()
+      payment_source = get(:payment_source, PaymentSource,
+                           {:card => PaymentSource::Card, :bank_account => PaymentSource::BankAccount, :amazon_payment => PaymentSource::AmazonPayment, :paypal => PaymentSource::Paypal});
+      return payment_source;
     end
 
-    def third_party_payment_method() 
-        third_party_payment_method = get(:third_party_payment_method, ThirdPartyPaymentMethod);
-        return third_party_payment_method;
+    def third_party_payment_method()
+      third_party_payment_method = get(:third_party_payment_method, ThirdPartyPaymentMethod);
+      return third_party_payment_method;
     end
 
-    def virtual_bank_account() 
-        virtual_bank_account = get(:virtual_bank_account, VirtualBankAccount);
-        return virtual_bank_account;
+    def virtual_bank_account()
+      virtual_bank_account = get(:virtual_bank_account, VirtualBankAccount);
+      return virtual_bank_account;
     end
 
-    def card() 
-        card = get(:card, Card);
-        return card;
+    def card()
+      card = get(:card, Card);
+      return card;
     end
 
-    def promotional_credit() 
-        promotional_credit = get(:promotional_credit, PromotionalCredit);
-        return promotional_credit;
+    def promotional_credit()
+      promotional_credit = get(:promotional_credit, PromotionalCredit);
+      return promotional_credit;
     end
 
-    def invoice() 
-        invoice = get(:invoice, Invoice,
-        {:line_items => Invoice::LineItem, :discounts => Invoice::Discount, :line_item_discounts => Invoice::LineItemDiscount, :taxes => Invoice::Tax, :line_item_taxes => Invoice::LineItemTax, :linked_payments => Invoice::LinkedPayment, :applied_credits => Invoice::AppliedCredit, :adjustment_credit_notes => Invoice::AdjustmentCreditNote, :issued_credit_notes => Invoice::IssuedCreditNote, :linked_orders => Invoice::LinkedOrder, :notes => Invoice::Note, :shipping_address => Invoice::ShippingAddress, :billing_address => Invoice::BillingAddress});
-        return invoice;
+    def invoice()
+      invoice = get(:invoice, Invoice,
+                    {:line_items => Invoice::LineItem, :discounts => Invoice::Discount, :line_item_discounts => Invoice::LineItemDiscount, :taxes => Invoice::Tax, :line_item_taxes => Invoice::LineItemTax, :linked_payments => Invoice::LinkedPayment, :applied_credits => Invoice::AppliedCredit, :adjustment_credit_notes => Invoice::AdjustmentCreditNote, :issued_credit_notes => Invoice::IssuedCreditNote, :linked_orders => Invoice::LinkedOrder, :notes => Invoice::Note, :shipping_address => Invoice::ShippingAddress, :billing_address => Invoice::BillingAddress});
+      return invoice;
     end
 
-    def credit_note() 
-        credit_note = get(:credit_note, CreditNote,
-        {:line_items => CreditNote::LineItem, :discounts => CreditNote::Discount, :line_item_discounts => CreditNote::LineItemDiscount, :taxes => CreditNote::Tax, :line_item_taxes => CreditNote::LineItemTax, :linked_refunds => CreditNote::LinkedRefund, :allocations => CreditNote::Allocation});
-        return credit_note;
+    def credit_note()
+      credit_note = get(:credit_note, CreditNote,
+                        {:line_items => CreditNote::LineItem, :discounts => CreditNote::Discount, :line_item_discounts => CreditNote::LineItemDiscount, :taxes => CreditNote::Tax, :line_item_taxes => CreditNote::LineItemTax, :linked_refunds => CreditNote::LinkedRefund, :allocations => CreditNote::Allocation});
+      return credit_note;
     end
 
-    def unbilled_charge() 
-        unbilled_charge = get(:unbilled_charge, UnbilledCharge);
-        return unbilled_charge;
+    def unbilled_charge()
+      unbilled_charge = get(:unbilled_charge, UnbilledCharge);
+      return unbilled_charge;
     end
 
-    def order() 
-        order = get(:order, Order);
-        return order;
+    def order()
+      order = get(:order, Order);
+      return order;
     end
 
-    def transaction() 
-        transaction = get(:transaction, Transaction,
-        {:linked_invoices => Transaction::LinkedInvoice, :linked_credit_notes => Transaction::LinkedCreditNote, :linked_refunds => Transaction::LinkedRefund});
-        return transaction;
+    def transaction()
+      transaction = get(:transaction, Transaction,
+                        {:linked_invoices => Transaction::LinkedInvoice, :linked_credit_notes => Transaction::LinkedCreditNote, :linked_refunds => Transaction::LinkedRefund});
+      return transaction;
     end
 
-    def hosted_page() 
-        hosted_page = get(:hosted_page, HostedPage);
-        return hosted_page;
+    def hosted_page()
+      hosted_page = get(:hosted_page, HostedPage);
+      return hosted_page;
     end
 
-    def estimate() 
-        estimate = get(:estimate, Estimate, {},
-        {:subscription_estimate => SubscriptionEstimate, :invoice_estimate => InvoiceEstimate, :invoice_estimates => InvoiceEstimate, :next_invoice_estimate => InvoiceEstimate, :credit_note_estimates => CreditNoteEstimate, :unbilled_charge_estimates => UnbilledCharge});
-        estimate.init_dependant(@response[:estimate], :subscription_estimate,
-        {:shipping_address => SubscriptionEstimate::ShippingAddress});
-        estimate.init_dependant(@response[:estimate], :invoice_estimate,
-        {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
-        estimate.init_dependant(@response[:estimate], :next_invoice_estimate,
-        {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
-        estimate.init_dependant_list(@response[:estimate], :invoice_estimates,
-        {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
-        estimate.init_dependant_list(@response[:estimate], :credit_note_estimates,
-        {:line_items => CreditNoteEstimate::LineItem, :discounts => CreditNoteEstimate::Discount, :taxes => CreditNoteEstimate::Tax, :line_item_taxes => CreditNoteEstimate::LineItemTax, :line_item_discounts => CreditNoteEstimate::LineItemDiscount});
-        estimate.init_dependant_list(@response[:estimate], :unbilled_charge_estimates,
-        {});
-        return estimate;
+    def estimate()
+      estimate = get(:estimate, Estimate, {},
+                     {:subscription_estimate => SubscriptionEstimate, :invoice_estimate => InvoiceEstimate, :invoice_estimates => InvoiceEstimate, :next_invoice_estimate => InvoiceEstimate, :credit_note_estimates => CreditNoteEstimate, :unbilled_charge_estimates => UnbilledCharge});
+      estimate.init_dependant(@response[:estimate], :subscription_estimate,
+                              {:shipping_address => SubscriptionEstimate::ShippingAddress});
+      estimate.init_dependant(@response[:estimate], :invoice_estimate,
+                              {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
+      estimate.init_dependant(@response[:estimate], :next_invoice_estimate,
+                              {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
+      estimate.init_dependant_list(@response[:estimate], :invoice_estimates,
+                                   {:line_items => InvoiceEstimate::LineItem, :discounts => InvoiceEstimate::Discount, :taxes => InvoiceEstimate::Tax, :line_item_taxes => InvoiceEstimate::LineItemTax, :line_item_discounts => InvoiceEstimate::LineItemDiscount});
+      estimate.init_dependant_list(@response[:estimate], :credit_note_estimates,
+                                   {:line_items => CreditNoteEstimate::LineItem, :discounts => CreditNoteEstimate::Discount, :taxes => CreditNoteEstimate::Tax, :line_item_taxes => CreditNoteEstimate::LineItemTax, :line_item_discounts => CreditNoteEstimate::LineItemDiscount});
+      estimate.init_dependant_list(@response[:estimate], :unbilled_charge_estimates,
+                                   {});
+      return estimate;
     end
 
-    def plan() 
-        plan = get(:plan, Plan);
-        return plan;
+    def plan()
+      plan = get(:plan, Plan);
+      return plan;
     end
 
-    def addon() 
-        addon = get(:addon, Addon);
-        return addon;
+    def addon()
+      addon = get(:addon, Addon);
+      return addon;
     end
 
-    def coupon() 
-        coupon = get(:coupon, Coupon);
-        return coupon;
+    def coupon()
+      coupon = get(:coupon, Coupon);
+      return coupon;
     end
 
-    def coupon_set() 
-        coupon_set = get(:coupon_set, CouponSet);
-        return coupon_set;
+    def coupon_set()
+      coupon_set = get(:coupon_set, CouponSet);
+      return coupon_set;
     end
 
-    def coupon_code() 
-        coupon_code = get(:coupon_code, CouponCode);
-        return coupon_code;
+    def coupon_code()
+      coupon_code = get(:coupon_code, CouponCode);
+      return coupon_code;
     end
 
-    def address() 
-        address = get(:address, Address);
-        return address;
+    def address()
+      address = get(:address, Address);
+      return address;
     end
 
-    def event() 
-        event = get(:event, Event,
-        {:webhooks => Event::Webhook});
-        return event;
+    def event()
+      event = get(:event, Event,
+                  {:webhooks => Event::Webhook});
+      return event;
     end
 
-    def comment() 
-        comment = get(:comment, Comment);
-        return comment;
+    def comment()
+      comment = get(:comment, Comment);
+      return comment;
     end
 
-    def download() 
-        download = get(:download, Download);
-        return download;
+    def download()
+      download = get(:download, Download);
+      return download;
     end
 
-    def portal_session() 
-        portal_session = get(:portal_session, PortalSession,
-        {:linked_customers => PortalSession::LinkedCustomer});
-        return portal_session;
+    def portal_session()
+      portal_session = get(:portal_session, PortalSession,
+                           {:linked_customers => PortalSession::LinkedCustomer});
+      return portal_session;
     end
 
-    def site_migration_detail() 
-        site_migration_detail = get(:site_migration_detail, SiteMigrationDetail);
-        return site_migration_detail;
+    def site_migration_detail()
+      site_migration_detail = get(:site_migration_detail, SiteMigrationDetail);
+      return site_migration_detail;
     end
 
-    def resource_migration() 
-        resource_migration = get(:resource_migration, ResourceMigration);
-        return resource_migration;
+    def resource_migration()
+      resource_migration = get(:resource_migration, ResourceMigration);
+      return resource_migration;
     end
 
-    def time_machine() 
-        time_machine = get(:time_machine, TimeMachine);
-        return time_machine;
+    def time_machine()
+      time_machine = get(:time_machine, TimeMachine);
+      return time_machine;
     end
 
-    def export() 
-        export = get(:export, Export,
-        {:download => Export::Download});
-        return export;
+    def export()
+      export = get(:export, Export,
+                   {:download => Export::Download});
+      return export;
     end
 
 
     def unbilled_charges()
-        unbilled_charges = get_list(:unbilled_charges, UnbilledCharge,
-        {});
-        return unbilled_charges;
+      unbilled_charges = get_list(:unbilled_charges, UnbilledCharge,
+                                  {});
+      return unbilled_charges;
     end
-    
+
     def credit_notes()
-        credit_notes = get_list(:credit_notes, CreditNote,
-        {:line_items => CreditNote::LineItem, :discounts => CreditNote::Discount, :line_item_discounts => CreditNote::LineItemDiscount, :taxes => CreditNote::Tax, :line_item_taxes => CreditNote::LineItemTax, :linked_refunds => CreditNote::LinkedRefund, :allocations => CreditNote::Allocation});
-        return credit_notes;
+      credit_notes = get_list(:credit_notes, CreditNote,
+                              {:line_items => CreditNote::LineItem, :discounts => CreditNote::Discount, :line_item_discounts => CreditNote::LineItemDiscount, :taxes => CreditNote::Tax, :line_item_taxes => CreditNote::LineItemTax, :linked_refunds => CreditNote::LinkedRefund, :allocations => CreditNote::Allocation});
+      return credit_notes;
     end
-    
+
     def invoices()
-        invoices = get_list(:invoices, Invoice,
-        {:line_items => Invoice::LineItem, :discounts => Invoice::Discount, :line_item_discounts => Invoice::LineItemDiscount, :taxes => Invoice::Tax, :line_item_taxes => Invoice::LineItemTax, :linked_payments => Invoice::LinkedPayment, :applied_credits => Invoice::AppliedCredit, :adjustment_credit_notes => Invoice::AdjustmentCreditNote, :issued_credit_notes => Invoice::IssuedCreditNote, :linked_orders => Invoice::LinkedOrder, :notes => Invoice::Note, :shipping_address => Invoice::ShippingAddress, :billing_address => Invoice::BillingAddress});
-        return invoices;
+      invoices = get_list(:invoices, Invoice,
+                          {:line_items => Invoice::LineItem, :discounts => Invoice::Discount, :line_item_discounts => Invoice::LineItemDiscount, :taxes => Invoice::Tax, :line_item_taxes => Invoice::LineItemTax, :linked_payments => Invoice::LinkedPayment, :applied_credits => Invoice::AppliedCredit, :adjustment_credit_notes => Invoice::AdjustmentCreditNote, :issued_credit_notes => Invoice::IssuedCreditNote, :linked_orders => Invoice::LinkedOrder, :notes => Invoice::Note, :shipping_address => Invoice::ShippingAddress, :billing_address => Invoice::BillingAddress});
+      return invoices;
     end
-    
+
 
     private
     def get_list(type, klass, sub_types = {}, dependant_types = {}, dependant_sub_types = {})
@@ -203,7 +203,7 @@ module ChargeBee
         when Hash
           model = klass.construct(obj, sub_types, dependant_types)
           dependant_sub_types.each do |k,v|
-        		model.init_dependant(obj, k, v);
+            model.init_dependant(obj, k, v);
           end
           set_val.push(model)
         end
@@ -216,8 +216,8 @@ module ChargeBee
       return klass.construct(@response[type], sub_types, dependant_types)
     end
 
-    def to_s(*args) 
-      JSON.pretty_generate(@response) 
+    def to_s(*args)
+      MultiJson.dump(@response)
     end
 
   end

--- a/spec/chargebee/list_result_spec.rb
+++ b/spec/chargebee/list_result_spec.rb
@@ -3,42 +3,42 @@ require "spec_helper"
 describe ChargeBee::ListResult do
   let(:response) do
     {:list=>
-      [{:customer=>
-         {:id=>"d0cus3orh6gnjgha1i",
-          :first_name=>"Test Name1",
-          :last_name=>"Test last name 1",
-          :email=>"name1@gmail.com",
-          :auto_collection=>"on",
-          :created_at=>1346258514,
-          :object=>"customer",
-          :card_status=>"valid"},
-        :card=>
-         {:customer_id=>"d0cus3orh6gnjgha1i",
-          :status=>"valid",
-          :gateway=>"chargebee",
-          :first_name=>"Test Name1",
-          :last_name=>"Test last name 1",
-          :iin=>"32122",
-          :last4=>"1333",
-          :card_type=>"visa",
-          :expiry_month=>8,
-          :expiry_year=>2013,
-          :billing_addr1=>"Flat 11",
-          :billing_addr2=>"51 Strit",
-          :billing_city=>"Bristol",
-          :billing_state=>"Somerset",
-          :billing_zip=>"BS1 4HQ",
-          :object=>"card",
-          :masked_number=>"21323****4323"}},
-       {:customer=>
-         {:id=>"cwtid6smh67tq3z51l",
-          :first_name=>"Test Name 2",
-          :last_name=>"Test last name 2",
-          :email=>"name2@gmail.com",
-          :auto_collection=>"on",
-          :created_at=>1345724673,
-          :object=>"customer",
-          :card_status=>"no_card"}}],
+     [{:customer=>
+       {:id=>"d0cus3orh6gnjgha1i",
+        :first_name=>"Test Name1",
+        :last_name=>"Test last name 1",
+        :email=>"name1@gmail.com",
+        :auto_collection=>"on",
+        :created_at=>1346258514,
+        :object=>"customer",
+        :card_status=>"valid"},
+       :card=>
+       {:customer_id=>"d0cus3orh6gnjgha1i",
+        :status=>"valid",
+        :gateway=>"chargebee",
+        :first_name=>"Test Name1",
+        :last_name=>"Test last name 1",
+        :iin=>"32122",
+        :last4=>"1333",
+        :card_type=>"visa",
+        :expiry_month=>8,
+        :expiry_year=>2013,
+        :billing_addr1=>"Flat 11",
+        :billing_addr2=>"51 Strit",
+        :billing_city=>"Bristol",
+        :billing_state=>"Somerset",
+        :billing_zip=>"BS1 4HQ",
+        :object=>"card",
+        :masked_number=>"21323****4323"}},
+      {:customer=>
+       {:id=>"cwtid6smh67tq3z51l",
+        :first_name=>"Test Name 2",
+        :last_name=>"Test last name 2",
+        :email=>"name2@gmail.com",
+        :auto_collection=>"on",
+        :created_at=>1345724673,
+        :object=>"customer",
+        :card_status=>"no_card"}}],
      :next_offset=>"[\"1345724673000\",\"1510\"]"}
   end
 
@@ -48,6 +48,6 @@ describe ChargeBee::ListResult do
 
   it "returns list object, with next offset attribute" do
     list = ChargeBee::Request.send(:customer, "http://url.com", {:limit => 2})
-    list.next_offset.should =~ ["1345724673000", "1510"]
+    list.next_offset.should == "[\"1345724673000\",\"1510\"]"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,6 @@ def mock_response(body, code=200)
 end
 
 ChargeBee.configure(
-  :api_key => "dummy_api_key", 
+  :api_key => "dummy_api_key",
   :site => "dummy_site"
 )


### PR DESCRIPTION
This switches out json_pure for multi_json. json_pure stops some rubyists from utilizing your service because it is incompatible with other json libraries they might be using. This is a drop in replacement and no loss of functionality or speed will occur for existing users. Furthermore, customers using other json libraries like oj will have a marked speed increase.

Also, I added a Gemfile so I could easily install your gems, fixed a broken test and edited a redundant line of code.

Thanks for considering this!