### PR TITLE
Make #to_s public in Result

### DIFF
--- a/lib/chargebee/result.rb
+++ b/lib/chargebee/result.rb
@@ -206,9 +206,14 @@ module ChargeBee
         {:line_items => Invoice::LineItem, :discounts => Invoice::Discount, :line_item_discounts => Invoice::LineItemDiscount, :taxes => Invoice::Tax, :line_item_taxes => Invoice::LineItemTax, :line_item_tiers => Invoice::LineItemTier, :linked_payments => Invoice::LinkedPayment, :applied_credits => Invoice::AppliedCredit, :adjustment_credit_notes => Invoice::AdjustmentCreditNote, :issued_credit_notes => Invoice::IssuedCreditNote, :linked_orders => Invoice::LinkedOrder, :notes => Invoice::Note, :shipping_address => Invoice::ShippingAddress, :billing_address => Invoice::BillingAddress});
         return invoices;
     end
+
+    def to_s(*args) 
+      JSON.pretty_generate(@response) 
+    end
     
 
     private
+    
     def get_list(type, klass, sub_types = {}, dependant_types = {}, dependant_sub_types = {})
       if(@response[type] == nil)
         return nil
@@ -227,14 +232,8 @@ module ChargeBee
       return instance_variable_set("@#{type}", set_val)
     end
 
-    private
     def get(type, klass, sub_types = {}, dependant_types = {})
       return klass.construct(@response[type], sub_types, dependant_types)
     end
-
-    def to_s(*args) 
-      JSON.pretty_generate(@response) 
-    end
-
   end
 end


### PR DESCRIPTION
This provides access to the API response, which is blocked in the current code.

Getting this simple access to the response made my integration work much easier because I could re-use my code which parses and handles webhook event payloads. Specifically, parsing out the Customer and Subscription information I'm saving in my application's database. I already have well tested code which can parse the raw JSON API responses. By getting access to `#to_s`, I'm able to leverage this gem's auth and request facilities, yet still access the raw response.

Unless there's some other way to get to the full JSON response? I didn't see it. It's possible that `#to_s` was marked `private` by accident.