### PR TITLE
Fix loading of false boolean values

### DIFF
--- a/lib/chargebee/models/model.rb
+++ b/lib/chargebee/models/model.rb
@@ -22,9 +22,8 @@ module ChargeBee
         values.each do |k, v|
           set_val = nil
           case v
-          when Hash && (@dependant_types[k] != nil)
-            next
           when Hash
+            next if @dependant_types[k] != nil
             set_val = (@sub_types[k] != nil) ? @sub_types[k].construct(v) : v
           when Array
             if(@sub_types[k] != nil)

--- a/spec/chargebee_spec.rb
+++ b/spec/chargebee_spec.rb
@@ -60,6 +60,7 @@ describe "chargebee" do
     s = result.subscription
     s.id.should eq("simple_subscription")
     s.plan_id.should eq('basic')
+    s.has_scheduled_changes.should eq(false)
     c = result.customer
     c.first_name.should eq('simple')
     c.last_name.should eq('subscription')

--- a/spec/sample_response.rb
+++ b/spec/sample_response.rb
@@ -16,7 +16,8 @@ def simple_subscription
   {
     :subscription => {
       :id => 'simple_subscription',
-      :plan_id => 'basic'
+      :plan_id => 'basic',
+      :has_scheduled_changes => false
     },
     :customer => {
       :first_name => 'simple',


### PR DESCRIPTION
When constructing a model and dynamically setting
its instance variables, false boolean values are being
skipped over; as a result, they default to nil.

This fixes the issue by moving the problematic case condition
within the load method to the appropriate execution block.