### PR TITLE
Upgrade CGI to fix security vulnerabilities

### DIFF
--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json_pure', '~> 2.1')
   s.add_dependency('rest-client', '>=1.8', '<=2.0.2')
-  s.add_dependency('cgi', '<=0.1.0')
+  s.add_dependency('cgi', '>=0.1.0', '<1.0.0')
 
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2021/11/24/buffer-overrun-in-cgi-escape_html-cve-2021-41816/
and https://www.ruby-lang.org/en/news/2021/11/24/cookie-prefix-spoofing-in-cgi-cookie-parse-cve-2021-41819/

The CGI version was pinned in https://github.com/chargebee/chargebee-ruby/commit/01297e3cdbf1f8eb85c4dd68a49056edf9607237, with no meaningful explanation of why.

All tests pass, except for https://github.com/chargebee/chargebee-ruby/issues/60 which also fails on `master`.