### PR TITLE
#72 custom fields with spaces causing the API to fail

### DIFF
--- a/lib/chargebee/models/model.rb
+++ b/lib/chargebee/models/model.rb
@@ -35,8 +35,7 @@ module ChargeBee
                     else
                       v
                     end
-
-          instance_variable_set("@#{k}", set_val)
+          instance_variable_set("@#{format_instance_variable_name(k)}", set_val)
         end
       end
     end
@@ -82,6 +81,15 @@ module ChargeBee
           end
         end
       end
+    end
+
+    def format_instance_variable_name(name)
+      name.to_s.gsub(/::/, '/').
+        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+        gsub(/([a-z\d])([A-Z])/,'\1_\2').
+        tr("-", "_").
+        tr(" ", "_").
+        downcase
     end
     
     def init_dependant_list(obj, type, sub_types = {})

--- a/spec/sample_response.rb
+++ b/spec/sample_response.rb
@@ -31,7 +31,8 @@ def simple_subscription
     },
     :customer => {
       :first_name => 'simple',
-      :last_name => 'subscription'
+      :last_name => 'subscription',
+      :'cf_my Custom Attributes' => 'value'
     }
   }
 end


### PR DESCRIPTION
Remove spaces and capitals from custom field names