### PR TITLE
Fixes new require tags in chargebee.rb

### DIFF
--- a/lib/chargebee.rb
+++ b/lib/chargebee.rb
@@ -70,8 +70,8 @@ require File.dirname(__FILE__) + '/chargebee/models/non_subscription.rb'
 require File.dirname(__FILE__) + '/chargebee/models/price_variant'
 require File.dirname(__FILE__) + '/chargebee/models/installment_detail'
 require File.dirname(__FILE__) + '/chargebee/models/ramp'
-require File.dirname(__FILE__) + '../lib/chargebee/models/business_entity'
-require File.dirname(__FILE__) + '../lib/chargebee/models/business_entity_transfer'
+require File.dirname(__FILE__) + '/chargebee/models/business_entity'
+require File.dirname(__FILE__) + '/chargebee/models/business_entity_transfer'
 
 module ChargeBee
 


### PR DESCRIPTION
Thanks for developing this SDK!

It seems like the latest code under tag 2.39.0 is faulty. The new require tags for business_entities are committed with a wrong path. This PR fixes this problem.