### PR TITLE
Add respond_to_missing? to ChargeBee::Model

### DIFF
--- a/lib/chargebee/models/model.rb
+++ b/lib/chargebee/models/model.rb
@@ -46,7 +46,7 @@ module ChargeBee
     end
 
     def respond_to_missing?(m, include_private = false)
-      @values.has_key?(m) || m[0,3] == "cf_"
+      @values.has_key?(m) || m[0,3] == "cf_" || super
     end
       
     def method_missing(m, *args, &block)


### PR DESCRIPTION
That will fix an issue when calling `flatten` to an array of `ChargeBee::Model`:

```ruby
resources.map(&:class).tally
#=> {ChargeBee::Transaction=>890,
 ChargeBee::Invoice=>712,
 ChargeBee::Customer=>17088,
 ChargeBee::Subscription=>14774,
 ChargeBee::PaymentSource=>534,
 ChargeBee::Card=>6942,
 ChargeBee::CreditNote=>178}

resources.flatten
#=> There's no method called to_ary [] here -- please try again.
```