### PR TITLE
Bump rest-client to 2.1.0

### DIFF
--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md LICENSE]
 
   s.add_dependency('json_pure', '~> 2.1')
-  s.add_dependency('rest-client', '>=1.8', '<=2.0.2')
+  s.add_dependency('rest-client', '>=1.8', '<=2.1.0')
   s.add_dependency('cgi', '>=0.1.0', '<1.0.0')
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('mocha')

--- a/lib/chargebee/rest.rb
+++ b/lib/chargebee/rest.rb
@@ -55,7 +55,12 @@ module ChargeBee
             raise IOError.new("IO Exception when trying to connect to chargebee with url #{opts[:url]} . Reason #{e}",e)        
       end
       rheaders = response.headers
+
       rbody = response.body
+      if headers.keys.any? { |k| k.downcase == 'accept-encoding' } && rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
+          rbody = Zlib::GzipReader.new(StringIO.new(rbody)).read
+      end
+
       rcode = response.code
       begin
         resp = JSON.parse(rbody)

--- a/lib/chargebee/rest.rb
+++ b/lib/chargebee/rest.rb
@@ -54,14 +54,17 @@ module ChargeBee
       rescue Exception => e
             raise IOError.new("IO Exception when trying to connect to chargebee with url #{opts[:url]} . Reason #{e}",e)        
       end
+
       rheaders = response.headers
 
       rbody = response.body
-      if headers.keys.any? { |k| k.downcase == 'accept-encoding' } && rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
-          rbody = Zlib::GzipReader.new(StringIO.new(rbody)).read
+      if headers.keys.any? { |k| k.downcase == 'accept-encoding' } &&
+         rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
+        rbody = Zlib::GzipReader.new(StringIO.new(rbody)).read
       end
 
       rcode = response.code
+
       begin
         resp = JSON.parse(rbody)
       rescue Exception => e


### PR DESCRIPTION
Allow rest-client dependency 2.1.0. 

Closes #55

Related to #43 and #50