### PR TITLE
Remove json-pure gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     chargebee (2.47.1)
       cgi (>= 0.1.0, < 1.0.0)
-      json_pure (~> 2.1)
       rest-client (>= 1.8, <= 2.0.2)
 
 GEM
@@ -15,7 +14,6 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    json_pure (2.6.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)

--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency('json_pure', '~> 2.1')
   s.add_dependency('rest-client', '>=1.8', '<=2.0.2')
   s.add_dependency('cgi', '>=0.1.0', '<1.0.0')
   s.add_development_dependency('rspec', '~> 3.0.0')


### PR DESCRIPTION
The 'json_pure' gem is unused. For the chargebee-ruby gem to use it, it requires a `require 'json/pure'` somewhere in the code.

Also, the json_pure gem is now an "empty gem": https://github.com/ruby/json/pull/685 (https://github.com/ruby/json/pull/685/files#diff-edf33b599deba1fe902a1b806befc626fd17bc5ff97b30d748d8e6bc43ac48f4R3)