### PR TITLE
Remove rest-client as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Install the latest version of the gem with the following command...
 ## Requirements
 
 * Ruby 1.9.3 or above.
-* rest-client
 
 ## Documentation
 


### PR DESCRIPTION
It looks like this release made rest-client no longer a requirement: https://github.com/chargebee/chargebee-ruby/commit/4c697f9fb8cec5cde7778fed9c3a7f803ce54c20