### PR TITLE
Fix: Allow unzip even when custom headers not present

### DIFF
--- a/lib/chargebee/nativeRequest.rb
+++ b/lib/chargebee/nativeRequest.rb
@@ -73,7 +73,7 @@ module ChargeBee
       # decompress the response. Therefore, we need to manually handle decompression
       # based on the 'Content-Encoding' header in the response.
       # https://github.com/ruby/ruby/blob/19c1f0233eb5202403c52b196f1d573893eacab7/lib/net/http/generic_request.rb#L82
-      if headers.keys.any? { |k| k.downcase == 'accept-encoding' } && rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
+      if rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
         rbody = Zlib::GzipReader.new(StringIO.new(rbody)).read
       end
 

--- a/lib/chargebee/nativeRequest.rb
+++ b/lib/chargebee/nativeRequest.rb
@@ -73,7 +73,7 @@ module ChargeBee
       # decompress the response. Therefore, we need to manually handle decompression
       # based on the 'Content-Encoding' header in the response.
       # https://github.com/ruby/ruby/blob/19c1f0233eb5202403c52b196f1d573893eacab7/lib/net/http/generic_request.rb#L82
-      if rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
+      if !headers.keys.any? { |k| k.downcase == 'accept-encoding' } && rheaders[:content_encoding] == 'gzip' && rbody && !rbody.empty?
         rbody = Zlib::GzipReader.new(StringIO.new(rbody)).read
       end
 


### PR DESCRIPTION
When trying to upgrade from 2.48.0 we are getting lots of tests failing due to the missing header. Even if the vcr recording that we have includes the header.
I think it would be reasonable to unzip the response body if it is zipped, something that seems like was the case before the change to NativeRequest, although I might be wrong.
![Screenshot From 2025-03-13 13-39-52](https://github.com/user-attachments/assets/811f5bf8-6fff-432e-9268-c0e0a1f13b94)
