### PR TITLE
Add `ForbiddenError` exception for 403 HTTP responses

### DIFF
--- a/chargebee.gemspec
+++ b/chargebee.gemspec
@@ -140,7 +140,7 @@ Gem::Specification.new do |s|
     lib/chargebee/models/usage_file.rb
     lib/chargebee/models/virtual_bank_account.rb
     lib/chargebee/models/webhook_endpoint.rb
-    lib/chargebee/nativeRequest.rb
+    lib/chargebee/native_request.rb
     lib/chargebee/request.rb
     lib/chargebee/rest.rb
     lib/chargebee/result.rb

--- a/lib/chargebee.rb
+++ b/lib/chargebee.rb
@@ -1,5 +1,5 @@
 require File.dirname(__FILE__) + '/chargebee/environment'
-require File.dirname(__FILE__) + '/chargebee/nativeRequest'
+require File.dirname(__FILE__) + '/chargebee/native_request'
 require File.dirname(__FILE__) + '/chargebee/util'
 require File.dirname(__FILE__) + '/chargebee/request'
 require File.dirname(__FILE__) + '/chargebee/result'

--- a/lib/chargebee/errors.rb
+++ b/lib/chargebee/errors.rb
@@ -8,6 +8,8 @@ module ChargeBee
     end
   end
 
+  class ForbiddenError < Error; end
+
   class IOError < Error; end
 
   class APIError < Error

--- a/spec/chargebee/native_request_spec.rb
+++ b/spec/chargebee/native_request_spec.rb
@@ -141,6 +141,19 @@ module ChargeBee
       end
     end
 
+    it "raises ForbiddenError for 403 status code" do
+      stub_request(:get, "https://dummy.chargebee.com/test").to_return(
+        body: "<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body>\r\n<center><h1>403 Forbidden</h1></center>\r\n</body>\r\n</html>\r\n",
+        status: 403
+      )
+
+      expect {
+        NativeRequest.request(:get, "/test", env)
+      }.to raise_error(ForbiddenError) do |err|
+        expect(err.message).to eq("Access forbidden. You do not have permission to access this resource.")
+      end
+    end
+
     it "retries once on HTTP 503 and succeeds on second attempt" do
       stub_request(:get, "https://dummy.chargebee.com/test")
         .to_return({ status: 503, body: "temporary error" },


### PR DESCRIPTION
## Summary
  
Adds a new `ForbiddenError` exception class to properly handle HTTP 403 Forbidden responses from the ChargeBee API. This provides better error handling and allows applications to distinguish between forbidden access errors and other API errors.

## Changes

### Error Handling
  - Added new `ForbiddenError` class that inherits from `Error`
  - Enhanced `handle_for_error` method to detect and handle 403 status codes
  - Provides clear error message: "Access forbidden. You do not have permission to access this resource."

### Code Quality Improvements
  - Renamed `lib/chargebee/nativeRequest.rb` → `lib/chargebee/native_request.rb` to follow Ruby naming conventions
  - Refactored `handle_for_error` to return error objects instead of raising them inline (cleaner separation of concerns)
  - Added YARD documentation for `handle_for_error` method

### Testing
  - Added comprehensive test coverage for 403 error scenarios

## Motivation
  When API keys lack permissions or access is restricted, the ChargeBee API returns a 403 status code. Previously, this was handled as a generic error, making it difficult for applications to distinguish permission issues from other error types. With `ForbiddenError`, applications can now:

  - Catch and handle permission errors specifically
  - Provide better user feedback about access issues
  - Implement custom retry or fallback logic for authorization failures

## Example Usage

```ruby

begin
  ChargeBee::Customer.update(...)
rescue ChargeBee::ForbiddenError => e
  # Handle permission errors specifically
rescue ChargeBee::APIError => e
  # Handle other API errors
end
```