### PR TITLE
ci: fail release if gem manifest is out of date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,20 @@ jobs:
           fi
           echo "✅ Tag matches gemspec version."
 
+      - name: Verify gem manifest is up to date
+        run: |
+          make update-manifest
+          if ! git diff --quiet -- chargebee.gemspec; then
+            echo "❌ Gem manifest in chargebee.gemspec is out of date."
+            echo "Some files tracked in the repo are missing from (or stale in) s.files,"
+            echo "which means they would not be packaged into the released gem."
+            echo "Run 'make update-manifest' locally and commit the updated chargebee.gemspec."
+            echo "----- diff -----"
+            git --no-pager diff -- chargebee.gemspec
+            exit 1
+          fi
+          echo "✅ Gem manifest is up to date."
+
       - name: Build gem
         run: gem build chargebee.gemspec
 


### PR DESCRIPTION
The release workflow built the gem directly without regenerating the s.files manifest in chargebee.gemspec. When new files were added but the manifest was not updated, they were silently excluded from the published gem. Add a step that runs `make update-manifest` and fails the release if chargebee.gemspec differs, preventing missing build artifacts. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Release workflow now regenerates the gem manifest before publishing and fails if `chargebee.gemspec` is out of date. This ensures the committed `s.files` list matches the generated manifest, preventing missing files from being omitted from the packaged gem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->